### PR TITLE
Fix cleanup behavior in useAbortable

### DIFF
--- a/packages/@cruise-automation/hooks/src/useAbortable.js
+++ b/packages/@cruise-automation/hooks/src/useAbortable.js
@@ -44,7 +44,8 @@ export default function useAbortable<T>(
     return () => {
       setResult(defaultValue);
       // on unmount or args changing clean up the old value
-      promise.then(cleanup);
+      // ensure cleanup is called even if the async action rejects
+      promise.then(cleanup, () => cleanup(undefined));
       controller.abort();
     };
   }, args);

--- a/packages/@cruise-automation/hooks/src/useAbortable.test.js
+++ b/packages/@cruise-automation/hooks/src/useAbortable.test.js
@@ -145,4 +145,17 @@ describe("useAbortable", () => {
     expect(cleanup1).toHaveBeenCalledWith("done1");
     await done2;
   });
+
+  it("cleans up even if the action rejects", async () => {
+    const cleanedup = signal();
+    const action = async () => {
+      throw new Error("bad");
+    };
+    const cleanup = (value) => cleanedup.resolve(value);
+    const App = () => <Test action={action} cleanup={cleanup} />;
+    const el = mount(<App />);
+    el.unmount();
+    const value = await cleanedup;
+    expect(value).toEqual(undefined);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure cleanup callback runs even when the async action rejects
- add regression test for useAbortable rejection handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a1af3615c83248111d2ce299251ef